### PR TITLE
Add Ajax for Unfollow butten

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Then go to http://localhost:5000 to see the result
 
 ### ToDo
 
-- Unfollow should be applied in-place (With JQuery maybe) 
 - Support two-step authentication
+- User should be able to follow again after unfollow
 
 ### Contributers
 

--- a/main.py
+++ b/main.py
@@ -37,6 +37,5 @@ def unf():
     # Handles unfollow buttens. requests will be sent using POST
     unf = request.form['unfollow']
     insta.unfollow(unf)
-    return render_template('unfollow.html', unf=unf)
 
 app.run(debug=True)

--- a/static/js/unfollow.js
+++ b/static/js/unfollow.js
@@ -1,0 +1,10 @@
+function unfollow(username){
+    var req = new XMLHttpRequest();
+    req.open("POST", "unf", true);
+    req.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+    req.send("unfollow=" + username);
+    console.log(req.responseText);
+    unfbtn = document.getElementById("butten-unf-" + username);
+    unfbtn.innerHTML = "Unfollowed";
+    unfbtn.setAttribute("disabled", "true");
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,6 +8,7 @@
 		<link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" />
 		<!--[if lte IE 9]><link rel="stylesheet" href="{{ url_for('static', filename='css/ie9.css') }}" /><![endif]-->
 		<!--[if lte IE 8]><link rel="stylesheet" href="{{ url_for('static', filename='css/ie8.css') }}" /><![endif]-->
+        <script src="{{ url_for('static', filename='js/unfollow.js') }}"></script>
 	</head>
 	<body>
 
@@ -100,7 +101,7 @@
 														<td>{{ frow['full_name'] }}</td>
 														<td class="icon fa-instagram"> {{ frow['username'] }}</td>
 														<td class="link-fixed"><a href="https://instagram.com/{{ frow['username'] }}" class="button special">Visit Page</a></td>
-														<td class="link-fixed"><form action="unf" method="POST"><button class="button special" type="submit" name="unfollow" value="{{ frow['username'] }}">Unfollow</button></form></td>
+														<td class="link-fixed"><button onclick="unfollow('{{ frow['username'] }}')"  class="button special" id="butten-unf-{{ frow['username'] }}">Unfollow</button></td>
 													</tr>
 												{% endfor %}
 												</tbody>


### PR DESCRIPTION
Unfollow can be done in-place without refreshing the page.

TODO could be:
- User should be able to follow again after unfollow
- Unfollow fail messege (if Unfollow wasn't done, user should be prompted)